### PR TITLE
Permissive access to cache directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM node:7-slim
 ENV HOME=/home/shared
 RUN mkdir -p $HOME
 RUN chmod -R 777 $HOME
+RUN mkdir -p /home/shared/.cache/yarn/
+RUN chmod -R 777 /home/shared/.cache/yarn/
 
 # By default, run yarn
 ENTRYPOINT ["yarn"]


### PR DESCRIPTION
So that any old user can access the cache directory, e.g. when running
for local development as the local UID.

QA
--

Will knows.