### PR TITLE
Add support for bower.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM node:7-slim
+FROM node:7-alpine
 
-# Create a shared home directory
-# This helps anonymous users have a home
-ENV HOME=/home/shared
+# Expect to find the entrypoint script at /entrypoint
+ENTRYPOINT ["/entrypoint"]
+
+# Install bower
+RUN apk add --no-cache git
+RUN npm install -g bower@1.8.0
+
+# Create a shared home directory - this helps anonymous users have a home
 RUN mkdir -p $HOME
+RUN mkdir -p $HOME/.cache/yarn/
+RUN mkdir -p $HOME/.cache/bower/
 RUN chmod -R 777 $HOME
-RUN mkdir -p /home/shared/.cache/yarn/
-RUN chmod -R 777 /home/shared/.cache/yarn/
 
-# By default, run yarn
-ENTRYPOINT ["yarn"]
-
+# Add binaries
+ADD entrypoint /entrypoint

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 A light-weight docker image for running Yarn (https://yarnpkg.com/).
 
+It will also attempt to install bower dependencies if it finds a `bower.json`.
+
 ## Usage
 
 ``` bash
 docker run  \
   --user $(id -u):$(id -g)                       `# Use the current user inside container`  \
   --volume `pwd`:`pwd`                           `# Mirror current directory inside container`  \
-  --volume yarn-cache:/home/shared/.cache/yarn/  `# Add a persistent volume for the yarn cache`  \
+  --volume yarn-cache:/home/shared/.cache/       `# Add a persistent volume for the yarn cache`  \
   --workdir `pwd`                                `# Set current directory to the image's work directory`  \
   --tty                                          `# Attach a pseudo-terminal`  \
   --interactive                                  `# Add interactive capabilities to terminal prompt`  \
   yarn                                           `# Run the "yarn" docker image`
 ```
-

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,13 @@
+#! /usr/bin/env sh
+
+set -euo pipefail
+
+# Update gems, if anything's changed
+if [ -f "bower.json" ]; then
+    echo "Updating bower dependencies..." >> /dev/stderr
+    bower install  # Install new dependencies
+else
+    echo "bower.json not found - not installing bower dependencies" >> /dev/stderr
+fi
+
+yarn $@


### PR DESCRIPTION
- install bower in the image
- also, git, unfortunately
- make image smaller by basing it on `alpine`
- update readme, including suggesting they store the whole `.cache` dir
  for the image

QA
--


``` bash
docker build -t yarn .
git clone git@github.com:canonical-websites/tutorials.ubuntu.com
cd tutorials.ubuntu.com
docker run -ti -v `pwd`:`pwd` -w `pwd` -u $(id -u):$(id -g) yarn
```

Watch it install bower dependencies!

Now run it again:

``` bash
docker run -ti -v `pwd`:`pwd` -w `pwd` -u $(id -u):$(id -g) yarn
```

See that it doesn't install them again.

Now change something in "bower.json".

Run it again:

``` bash
docker run -ti -v `pwd`:`pwd` -w `pwd` -u $(id -u):$(id -g) yarn
```

Watch it update depencies.